### PR TITLE
新增 bookdex-plugin（书籍角色文本图鉴）索引

### DIFF
--- a/Function-Plugin.md
+++ b/Function-Plugin.md
@@ -5,6 +5,7 @@
 <!-- 请在表首添加新行 -->
 | 名称  |  作者  | 备注  |
 |-------| ----- |------ |
+| [书籍角色文本图鉴（bookdex-plugin）](https://github.com/KexinyingLife/bookdex-plugin) | [@KexinyingLife](https://github.com/KexinyingLife) | 原神书籍、角色故事、圣遗物、武器故事的文本检索与阅读插件，支持统一更新与搜索，首次使用请先执行 #统一更新 全量拉取数据。 |
 | [daily-Plugin](https://gitee.com/yll14/daily-plugin) | [@桉南](https：//gitee.com/yll14) | xingluo-plugin（星落插件）复活版，仅保留了热榜功能 |
 | [黑名单插件（yunzai-blacklist-plugin）](https://github.com/Sakura1618/yunzai-blacklist-plugin) | [@Sakura1618](https://github.com/Sakura1618) | 黑名单/授权管理插件，支持入群自动踢黑、自检踢黑、黑名单与管理名单查询以及主人授权，并在关键操作时私聊通知主人。 |
 | [wordle-plugin](https://gitee.com/qingyingxbot/wordle-plugin) | [@QingYingX](https://gitee.com/QingYingX) | 一款集合了 Wordle,Math,汉兜 的游戏插件 二改插件：) |


### PR DESCRIPTION
按照 CONTRIBUTING.md 格式，在 Function-Plugin.md 表首新增插件条目。

插件仓库：https://github.com/KexinyingLife/bookdex-plugin

备注：首次使用需执行 #统一更新 全量拉取数据。