### PR TITLE
添加 Huitian-daily 与 Huitian-mini 至 Function-Plugin.md

### DIFF
--- a/Function-Plugin.md
+++ b/Function-Plugin.md
@@ -5,6 +5,8 @@
 <!-- 请在表首添加新行 -->
 | 名称  |  作者  | 备注  |
 |-------| ----- |------ |
+| [Huitian-daily](https://github.com/OriginSXC/Huitian-daily) | [@OriginSXC](https://github.com/OriginSXC) | 回天日报聚合插件，把 60s、番剧、摸鱼、Epic、油价、历史上的今天等多源日报拼成派蒙主题图卡。|
+| [Huitian-mini](https://github.com/OriginSXC/Huitian-mini) | [@OriginSXC](https://github.com/OriginSXC) | 轻量级 Yunzai 插件合集：早报、摸鱼日历、米游社 COS、WP 抓图、随机图/视频。|
 | [Git-Plugin](https://github.com/QingYingX-Bot/Git-Plugin) | [@QingYingX](https://github.com/QingYingX) | Yunzai 的 Git 仓库助手，支持 GitHub、Gitee、GitCode、Gitea 四个平台。|
 | [官机全局按钮替换](https://gitee.com/wind-trace-typ/replaceButton-plugin)|  [@风之迹](https://gitee.com/wind-trace-typ) | 本插件主要用于trss官机按钮的替换，可根据拦截规则拦截对应指令的响应，然后替换里面的按钮为你自己设计的按钮 |
 | [本地网易云api插件(NCMApi-plugin)](https://github.com/sarsxe/NCMApi-plugin) | [sarsxe](https://github.com/sarsxe) | 简易方便的本地api，安装后重启即可用，可在解析插件上等使用。|


### PR DESCRIPTION
在 Function-Plugin.md 表首添加两个插件条目：

- **Huitian-daily** — <https://github.com/OriginSXC/Huitian-daily>
  回天日报聚合插件，把 60s、番剧、摸鱼、Epic、油价、历史上的今天等多源日报拼成派蒙主题图卡。

- **Huitian-mini** — <https://github.com/OriginSXC/Huitian-mini>
  轻量级 Yunzai 插件合集：早报、摸鱼日历、米游社 COS、WP 抓图、随机图/视频。

均为 Yunzai / TRSS / Miao / NapCat(OneBot v11) 通用的 class 插件，已在 GitHub 与 Gitee 镜像同步维护。